### PR TITLE
Changes grids to be symmetric for cleaner FFTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ Manifest.toml
 
 # Jupyter files
 **/.ipynb_checkpoints/
+
+#VSCode settings
+settings.json
+
+# Pluto notebooks
+notebooks/

--- a/src/SupportGrids.jl
+++ b/src/SupportGrids.jl
@@ -6,8 +6,8 @@ module SupportGrids
 using RecipesBase: @recipe
 import Base.*, Base.+, Base.-
 
-using FFTW: unsafe_execute!, assert_applicable, fftfreq, rfftfreq
-using FFTW: plan_fft, plan_rfft, plan_ifft, plan_irfft
+using FFTW: unsafe_execute!, assert_applicable, fftshift, fft, bfft
+using FFTW: plan_fft, plan_rfft, plan_bfft, plan_brfft
 using FFTW.AbstractFFTs: Plan, ScaledPlan
 
 using LinearAlgebra: ⋅
@@ -16,39 +16,37 @@ using LinearAlgebra: ⋅
 # Export #
 ##########
 export
-  SupportGrid,
-  AbstractNonlinearGrid,
-  AbstractGridOps,
-  # CompositeGrid,
-  # ExpGrid,
-  # ExpTanGrid,
-  # ExpExpGrid,
-  # InvLogGrid,
-  # InvLogTanGrid,
-  LinearGrid,
-  # LogGrid,
-  # LogTanGrid,
-  # SqrtGrid,
-  # TanGrid,
-  
-  fft,
-  fft!,
-  ifft,
-  ifft!,
+    SupportGrid,
+    AbstractNonlinearGrid,
+    AbstractGridOps,
+    # CompositeGrid,
+    # ExpGrid,
+    # ExpTanGrid,
+    # ExpExpGrid,
+    # InvLogGrid,
+    # InvLogTanGrid,
+    LinearGrid,
+    # LogGrid,
+    # LogTanGrid,
+    # SqrtGrid,
+    # TanGrid,
 
-  derivative,
-  # derivative!,
-  integrate,
-  integrate!,
-  convolution,
-  convolution!,
-  crosscorrelation,
-  crosscorrelation!,
-  hilbert,
-  hilbert!,
-  
-  invert_grid,
-  print_gridparams
+    ft,
+    ft!,
+    bft,
+    bft!,
+    derivative,
+    # derivative!,
+    integrate,
+    integrate!,
+    convolution,
+    convolution!,
+    crosscorrelation,
+    crosscorrelation!,
+    hilbert,
+    hilbert!,
+    invert_grid,
+    print_gridparams
 
 #############
 # Abstracts #
@@ -99,6 +97,6 @@ export xcorr#, xcorr!
 ####################
 # Plotting recipes #
 ####################
-@recipe f(::Type{T}, grid::T) where T <: SupportGrid = grid.points
+@recipe f(::Type{T}, grid::T) where {T<:SupportGrid} = grid.points
 
 end

--- a/src/grids/linear_grid.jl
+++ b/src/grids/linear_grid.jl
@@ -1,211 +1,212 @@
 """
     LinearGridOps(points::Vector{T}, complex_op::Bool;
                   integration_method::Symbol=:trapz,
-                  δ::T=-(extrema(points)...)/(length(points)-1)) where T
+                  d::T=-(extrema(points)...)/(length(points)-1)) where T
 
 Generates the necessary tools for operations on the `LinearGrid` with `points` of
-discretization `δ`. For `integration_method` options, see [`integral_weights`](@ref).
+discretization `d`. For `integration_method` options, see [`integral_weights`](@ref).
 
 # Fields
 - `weights`: Integration weights.
-- `ft`, `ft⁻¹`: FFT and inverse FFT plans by [`FFTW`](@ref).
+- `ft_p`, `bft_p`: FFT and backwards FFT plans by [`FFTW`](@ref).
 - `frequencies`: Points in Fourier space.
 - `padded`: Work array for padded vector / FFT input.
 - `ft_work1`, `ft_work2`, `ft⁻¹_work`: Work array for (inverse) FFT output.
-- `ft_shift`, `ft⁻¹_shift`: FFT Phase and scale correction due to grid offset.
-- `conv_shift`: Same as above with added scaling for `conv`.
 - `fft_x⁻¹`: Fourier transform of `1/x` used for the Hilbert transform.
+- `ft_arr`: Array needed for the Fourier transforms.
 
 See also [`LinearGridOps`](@ref).
 """
+
 struct LinearGridOps{T} <: AbstractGridOps{T}
-  weights::Vector{T}
-  ft::Plan
-  ft⁻¹::ScaledPlan
-  frequencies::Vector{T}
-  padded::Vector{<:Union{T, Complex{T}}}
-  ft_work1::Vector{Complex{T}}
-  ft_work2::Vector{Complex{T}}
-  ft⁻¹_work::Vector{<:Union{T, Complex{T}}}
-  ft_shift::Vector{Complex{T}}
-  ft⁻¹_shift::Vector{Complex{T}}
-  conv_shift::Vector{Complex{T}}
-  fft_x⁻¹::Vector{Complex{T}}
-  
-  function LinearGridOps(points::Vector{T}, complex_op::Bool;
-      integration_method::Symbol=:trapz, δ::T=-(extrema(points)...)/(length(points)-1)
-      ) where T
-    weights = integration_weights(points, integration_method)
-    padded_len = nextpow(2, 2*length(points)-1) # double the lebgth and fill to the next power of 2
-    if T <: BigFloat len_padded -= 1 end # Why?
-    
-    padded = zeros(complex_op ? Complex{T} : T, padded_len)
-    ft⁻¹_work = similar(padded)
-    ft = complex_op ? plan_fft(ft⁻¹_work) : plan_rfft(ft⁻¹_work)
-    ft_work1 = zeros(Complex{T}, ft.osz)
-    ft_work2 = zeros(Complex{T}, ft.osz)
-    ft⁻¹ = complex_op ? plan_ifft(ft_work1) : plan_irfft(ft_work1, padded_len)
-    
-    frequencies = complex_op ? fftfreq(padded_len) : rfftfreq(padded_len)
-    ωₛ = points[1] * 2π * frequencies / δ # Phases due to the original domain offset
-    
-    # Includes scale of unitary FT
-    ft_shift = exp.(-im * ωₛ) * δ
-    ft⁻¹_shift = exp.(im * ωₛ) * ft⁻¹.scale / δ
-    conv_shift = ft_shift * ft⁻¹.scale
-    fft_x⁻¹ = -im * sign.(frequencies) * ft⁻¹.scale
-    
-    new{T}(weights,ft,ft⁻¹,frequencies,padded,ft_work1,ft_work2,ft⁻¹_work,
-      ft_shift,ft⁻¹_shift,conv_shift,fft_x⁻¹)
-  end
+    weights::Vector{T}
+    ft_p::Plan
+    bft_p::Plan
+    frequencies::Vector{T}
+    padded::Vector{<:Union{T,Complex{T}}}
+    ft_work1::Vector{Complex{T}}
+    ft_work2::Vector{Complex{T}}
+    bft_work::Vector{<:Union{T,Complex{T}}}
+    fft_x⁻¹::Vector{Complex{T}}
+    ft_arr::Vector{Int}
+    data_range::UnitRange{Int}
+
+    function LinearGridOps(points::Vector{T}, complex_op::Bool;
+        integration_method::Symbol=:trapz, d::T=abs(+(extrema(points)...))
+    ) where {T}
+
+        len = length(points)
+
+        weights = integration_weights(points, integration_method)
+
+        # double the length and fill to the next power of 2
+        padded_len = nextpow(2, 2 * len - 1)
+
+        padded = zeros(complex_op ? Complex{T} : T, padded_len)
+        bft_work = similar(padded)
+
+        ft_p = complex_op ? plan_fft(bft_work) : plan_rfft(bft_work)
+
+        ft_work1 = zeros(Complex{T}, ft_p.osz)
+        ft_work2 = zeros(Complex{T}, ft_p.osz)
+
+        bft_p = complex_op ? plan_bfft(ft_work1) : plan_brfft(ft_work1, padded_len)
+
+        dk = 2π / (padded_len * d)
+
+        ft_points = dk .* (collect(0:(padded_len-1)) .- padded_len ÷ 2)
+
+        ft_arr = [(-1)^(i - 1) for (i, _) in enumerate(ft_work1)]
+
+        fft_x⁻¹ = im * sign.(ft_points)
+
+        data_range = len÷2+1:len+len÷2
+
+        new{T}(weights, ft_p, bft_p, ft_points, padded, ft_work1, ft_work2, bft_work,
+            fft_x⁻¹, ft_arr, data_range)
+    end
 end
 
 """
-    LinearGrid(xmin::Real, xmax::Real, len::Int; complex_op=false, T::Type=Float64)
+    LinearGrid(grid_min::Real, len::Int; complex_op=true, T::Type=Float64)
 
-Generates an equidistant grid from `xmin` to `xmax` with `len` points. If operations on
-complex arrays are expected, `complex_op` should be set to `true`.
+Generates a symmetric equidistant grid from `grid_min` to `-grid_min` with `len` points.
+If operations on real arrays are expected, `complex_op` should be set to `false`.
 
 # Fields
-- `xmin`, `xmax`, `len` defined above.
+- `grid_min`, `len` defined above.
 - `points`: Vector of grid points `pᵢ`.
-- `δ`: Discretisation parameter of `points`, i.e. `pᵢ₊₁ = pᵢ + δ`.
+- `d`: Discretisation parameter of `points`, i.e. `pᵢ₊₁ = pᵢ + d`.
 - `op`: Tools for operations on this `LinearGrid`.
 
 See also [`LinearGridOps`](@ref).
 """
 struct LinearGrid{T} <: SupportGrid{T}
-  xmin::T               # Left bound
-  xmax::T               # Right bound
-  len::Int              # Number of points
-  points::Vector{T}     # Array of grid points
-  δ::T                  # Frequency discretisation
-  op::LinearGridOps{T}
+    grid_min::T            # Left bound
+    len::Int              # Number of points
+    points::Vector{T}     # Array of grid points
+    d::T                  # Discretisation parameter
+    op::LinearGridOps{T} # Tools for FFT operations on this grid
 
-  function LinearGrid(xmin::Real, xmax::Real, len::Int;
-      complex_op::Bool=false, T::Type=Float64
+    function LinearGrid(grid_min::Real, len::Int;
+        complex_op::Bool=true, T::Type=Float64
     )
-    indices = 0:(len-1)
-    
-    δ = (xmax - xmin) / (len - 1)
-    points = δ .* collect(indices) .+ xmin
-    points[end] = xmax
-    
-    new{T}(xmin, xmax, len, points, δ, LinearGridOps(points, complex_op; δ))
-  end
-  #
-  LinearGrid(::Type{T}, args...; kwargs...) where T = LinearGrid(args...; T, kwargs...)
+
+        indices = 0:(len-1)
+
+        d = 2abs(grid_min) / len
+
+        # Symmetric grid around 0, note that the last point is not included
+        points = d .* (collect(indices) .- len ÷ 2)
+
+        new{T}(grid_min, len, points, d, LinearGridOps(points, complex_op; d))
+    end
+    #
+    LinearGrid(::Type{T}, args...; kwargs...) where {T} = LinearGrid(args...; T, kwargs...)
 end
 
 """
 Apply FFT of grid to input
 """
-function fft!(grid::LinearGrid, out::AbstractVector, u::AbstractVector)
-  (; padded, ft, ft⁻¹, ft_shift) = grid.op
-  
-  assert_applicable(ft, padded, out)
-  unsafe_execute!(ft, _zeropad!(padded, u), out)
-  @. out *= ft_shift
-  
-  return out
+function ft!(grid::LinearGrid, out::AbstractVector, u::AbstractVector)
+    return fftshift(bfft(u)) .* grid.op.ft_arr[1:length(u)] * grid.d
 end
 
-fft(grid::LinearGrid, u::AbstractVector) = fft!(grid, zero(grid.op.ft_work1), u)
+ft(grid::LinearGrid, u::AbstractVector) = ft!(grid, zero(u), copy(u))
 
 """
 Internal function that works on padded arrays
 """
-function _ifft!(grid::LinearGrid, out::AbstractVector, u::AbstractVector)
-  (; ft_work1, ft⁻¹, ft⁻¹_shift) = grid.op
-  
-  assert_applicable(ft⁻¹.p, ft_work1, out)
-  _zeropad!(ft_work1, u; fillzero=true)
-  @. ft_work1 *= ft⁻¹_shift
-  unsafe_execute!(ft⁻¹.p, ft_work1, out)
-  
-  return out
+function ift!(grid::LinearGrid, out::AbstractVector, u::AbstractVector)
+    return fftshift(fft(u)) .* grid.op.ft_arr[1:length(u)] * grid.d / 2π
 end
 
 """
 Apply inverse FFT of grid to input
 """
-ifft!(grid::LinearGrid, out::AbstractVector, u::AbstractVector
-  ) = out .= @views _ifft!(grid, grid.op.ft⁻¹_work, u)[1:grid.len]
 
-ifft(grid::LinearGrid, u::AbstractVector
-  ) = ifft!(grid, zeros(eltype(grid.op.ft⁻¹_work), grid.len), u)
+ift(grid::LinearGrid, u::AbstractVector) = ift!(grid, zero(u), copy(u))
 
 """
 Internal function that works on padded arrays
 """
 function _convolution!(grid::LinearGrid, out::AbstractVector,
-    u::AbstractVector,v::AbstractVector)
-  (; padded, ft_work1, ft_work2, ft, ft⁻¹, conv_shift) = grid.op
-  
-  assert_applicable(ft⁻¹.p, ft_work2, out)
-  unsafe_execute!(ft, _zeropad!(padded, u), ft_work1)
-  unsafe_execute!(ft, _zeropad!(padded, v), ft_work2)
-  @. ft_work2 *= ft_work1 * conv_shift
-  unsafe_execute!(ft⁻¹.p, ft_work2, out)
-  
-  return out
+    u::AbstractVector, v::AbstractVector)
+    (; padded, ft_work1, ft_work2, ft_p, bft_p, ft_arr) = grid.op
+
+    assert_applicable(bft_p, ft_work2, out)
+    unsafe_execute!(ft_p, _zeropad!(padded, u), ft_work1)
+    unsafe_execute!(ft_p, _zeropad!(padded, v), ft_work2)
+    @. ft_work2 *= ft_work1 * ft_arr
+
+    unsafe_execute!(bft_p, ft_work2, out)
+
+    out .*= grid.d / length(padded)
+
+    return out
 end
 
 """
 Convolution - takes non-padded arrays as input (and output)
 """
 convolution!(grid::LinearGrid, out::AbstractVector,
-  u::AbstractVector,v::AbstractVector
-  ) = out .= @views _convolution!(grid, grid.op.ft⁻¹_work, u, v)[1:grid.len]
+    u::AbstractVector, v::AbstractVector
+) = out .= @views _convolution!(grid, grid.op.bft_work, u, v)[grid.op.data_range]
 
 convolution(grid::LinearGrid, u::AbstractVector, v::AbstractVector
-  ) = convolution!(grid, zero(u), u, v)
+) = convolution!(grid, zeros(eltype(grid.op.padded), length(u)), u, v)
 
 """
 Internal function that works on padded arrays
 """
 function _crosscorrelation!(grid::LinearGrid, out::AbstractVector,
     u::AbstractVector, v::AbstractVector)
-  (; padded, ft_work1, ft_work2, ft, ft⁻¹, corr_shift) = grid.op
-  
-  assert_applicable(ft⁻¹.p, ft_work2, out)
-  unsafe_execute!(ft, _zeropad!(padded, u), ft_work1)
-  unsafe_execute!(ft, _zeropad!(padded, v), ft_work2)
-  @. ft_work2 *= conj(ft_work1 * corr_shift)
-  unsafe_execute!(ft⁻¹.p, ft_work2, out)
-  
-  return out
+    (; padded, ft_work1, ft_work2, ft_p, bft_p, ft_arr) = grid.op
+
+    assert_applicable(bft_p, ft_work2, out)
+    unsafe_execute!(ft_p, _zeropad!(padded, u), ft_work1)
+    unsafe_execute!(ft_p, _zeropad!(padded, v), ft_work2)
+
+    @. ft_work2 *= conj(ft_work1) * ft_arr
+    unsafe_execute!(bft_p, ft_work2, out)
+
+
+    out .*= grid.d / length(padded)
+
+    return out
 end
 
 """
 Cross-correlation - takes non-padded arrays as input (and output)
 """
 crosscorrelation!(grid::LinearGrid, out::AbstractVector,
-  u::AbstractVector, v::AbstractVector
-  ) = out .= @views _crosscorrelation!(grid, grid.op.ft⁻¹_work, u, v)[1:grid.len]
+    u::AbstractVector, v::AbstractVector
+) = out .= @views _crosscorrelation!(grid, grid.op.bft_work, u, v)[grid.op.data_range]
 
 crosscorrelation(grid::LinearGrid, u::AbstractVector, v::AbstractVector
-  ) = crosscorrelation!(grid, zero(u), u, v)
+) = crosscorrelation!(grid, zeros(eltype(grid.op.padded), length(u)), u, v)
 
 """
 Internal function that works on padded arrays
 """
 function _hilbert!(grid::LinearGrid, out::AbstractVector, u::AbstractVector)
-  (; padded, ft_work1, ft, ft⁻¹, fft_x⁻¹) = grid.op
-  
-  assert_applicable(ft⁻¹.p, ft_work1, out)
-  unsafe_execute!(ft, _zeropad!(padded, u), ft_work1)
-  @. ft_work1 *= fft_x⁻¹
-  unsafe_execute!(ft⁻¹.p, ft_work1, out)
-  
-  return out
+    (; padded, ft_work1, ft_p, bft_p, fft_x⁻¹) = grid.op
+
+    assert_applicable(bft_p, ft_work1, out)
+    unsafe_execute!(ft_p, _zeropad!(padded, u), ft_work1)
+    @. ft_work1 *= fft_x⁻¹
+    unsafe_execute!(bft_p, ft_work1, out)
+
+    out .*= 1 / length(padded)
+
+    return out
 end
 
 """
 Hilbert transform - takes non-padded arrays as input (and output)
 """
 hilbert!(grid::LinearGrid, out::AbstractVector, u::AbstractVector
-  ) = out .= @views _hilbert!(grid, grid.op.ft⁻¹_work, u)[1:grid.len]
+) = out .= @views _hilbert!(grid, grid.op.bft_work, u)[grid.op.data_range]
 
 hilbert(grid::LinearGrid, u::AbstractVector) = hilbert!(grid, zero(u), u)
 
@@ -213,5 +214,5 @@ hilbert(grid::LinearGrid, u::AbstractVector) = hilbert!(grid, zero(u), u)
 Get index of y on the mesh (not rounded - i.e. allow for interpolated values)
 """
 function invert_grid(grid::LinearGrid, y::Real)
-  return 1 + (y - grid.xmin) / grid.δ
+    return 1 + (y - grid.xmin) / grid.d
 end

--- a/src/utility.jl
+++ b/src/utility.jl
@@ -1,7 +1,7 @@
 """
     _zeropad!(padded::AbstractVector, u::AbstractVector; fillzero::Bool=false)
 
-Copies `u` to the front of `padded`.
+Copies `u` to the center of `padded`.
 Fills the rest of `padded` with zeros if `fillzero` is `true.
 
 This is inspired by the `_zeropad!` function of DSP`, which we do not import here to make
@@ -10,10 +10,17 @@ the package more lightweight. This version is simpler but suffices for `SupportG
 Note: this uses `unsafe_copyto!`.
 """
 @inline function _zeropad!(padded::AbstractVector, u::AbstractVector; fillzero::Bool=false)
-  u_len = length(u)
-  @views padded_data, padded_zeros = padded[1:u_len], padded[u_len+1:end]
-  if fillzero fill!(padded_zeros, 0) end
-  copyto!(padded_data, u)
-  
-  return padded
+
+    u_len = length(u)
+
+    mask = [u_len ÷ 2 + 1 ≤ i ≤ u_len + u_len ÷ 2 for (i, _) in enumerate(padded)]
+    mask2 = [!(i) for i in mask]
+
+    @views padded_data, padded_zeros = padded[mask], padded[mask2]
+    if fillzero
+        fill!(padded_zeros, 0)
+    end
+    copyto!(padded_data, u)
+
+    return padded
 end


### PR DESCRIPTION
Grids are now symmetric which simplifies ft_shift  and ft^(-1)_shift. Modified convolutions, cross correlations and Hilbert to work with this new grid discritisation. Various notational changes which are hopefully more intuitive .